### PR TITLE
lock struct uses only minutes now

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -4,39 +4,33 @@ import "fmt"
 
 // Clock represents clock implementation
 type Clock struct {
-	h int
 	m int
 }
 
 // New constructor for Clock Type
 func New(h int, m int) Clock {
-	min := h*60 + m
-	h, m = hourAndMinute(min)
-
-	return Clock{h, m}
+	h, m = hourAndMinute(h*60 + m)
+	return Clock{h*60 + m}
 }
 
 // Add method adds minutes to current instance
 func (c Clock) Add(a int) Clock {
-	t := c.h*60 + c.m + a
-	c.h = (t / 60) % 24
-	c.m = t % 60
-
+	h, m := hourAndMinute(c.m + a)
+	c.m = h*60 + m
 	return c
 }
 
 // Subtract method subtract minutes to current instance
 func (c Clock) Subtract(s int) Clock {
-	min := c.h*60 + c.m - s
-
-	c.h, c.m = hourAndMinute(min)
-
+	h, m := hourAndMinute(c.m - s)
+	c.m = h*60 + m
 	return c
 }
 
 // String stringer interface implementation
 func (c Clock) String() string {
-	return fmt.Sprintf("%0.2d:%0.2d", c.h, c.m)
+	h, m := hourAndMinute(c.m)
+	return fmt.Sprintf("%0.2d:%0.2d", h, m)
 }
 
 // hourAndMinute calculate hour and minute based on total number of mintues
@@ -58,5 +52,6 @@ func hourAndMinute(min int) (h, m int) {
 		m = 0
 		h = (h + 1) % 24
 	}
+
 	return
 }


### PR DESCRIPTION
Reuse of hourAndMinute func to achieve deep equality
Use only minutes in clock structure
Bench:

BenchmarkAddMinutes-8           18646808                64.4 ns/op             0 B/op          0 allocs/op
BenchmarkSubtractMinutes-8      18279968                62.3 ns/op             0 B/op          0 allocs/op
BenchmarkCreateClocks-8         56680575                18.5 ns/op             0 B/op          0 allocs/op